### PR TITLE
Fix ROS Launch with Gazebo instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ colcon build
 
 # run in ROS
 source install/setup.sh
-roslaunch aws_robomaker_bookstore_world bookstore.world
+roslaunch aws_robomaker_bookstore_world bookstore.launch
 ```
 
 # Building

--- a/package.xml
+++ b/package.xml
@@ -12,6 +12,9 @@
   <exec_depend>gazebo_ros</exec_depend>
   <exec_depend>gazebo</exec_depend>
   <exec_depend>gazebo_plugins</exec_depend>
+  <depend>turtlebot3_description</depend>
+  <depend>turtlebot3_navigation</depend>
+  <depend>turtlebot3_gazebo</depend>
 
   <!-- SLAM -->
   <!--

--- a/package.xml
+++ b/package.xml
@@ -12,9 +12,9 @@
   <exec_depend>gazebo_ros</exec_depend>
   <exec_depend>gazebo</exec_depend>
   <exec_depend>gazebo_plugins</exec_depend>
-  <depend>turtlebot3_description</depend>
-  <depend>turtlebot3_navigation</depend>
-  <depend>turtlebot3_gazebo</depend>
+  <exec_depend>turtlebot3_description</exec_depend>
+  <exec_depend>turtlebot3_navigation</exec_depend>
+  <exec_depend>turtlebot3_gazebo</exec_depend>
 
   <!-- SLAM -->
   <!--


### PR DESCRIPTION
- Adding required dependencies to the package.xml file so that colcon
build works correctly.
- Fix roslaunch command.

These were needed to be able to follow the "ROS Launch with Gazebo viewer" instructions with Kinetic + Gazebo 7. 

Tested by following new README instructions and running launch file and it launched correctly. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
