### PR TITLE
Remove turtlebot3_gazebo in package.xml

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,6 @@ project(aws_robomaker_bookstore_world)
 
 find_package(catkin REQUIRED COMPONENTS
   gazebo_ros
-  turtlebot3_description    
   turtlebot3_navigation  # required for copy of .rviz file
 )
 

--- a/package.xml
+++ b/package.xml
@@ -14,7 +14,6 @@
   <exec_depend>gazebo_plugins</exec_depend>
   <exec_depend>turtlebot3_description</exec_depend>
   <exec_depend>turtlebot3_navigation</exec_depend>
-  <exec_depend>turtlebot3_gazebo</exec_depend>
 
   <!-- SLAM -->
   <!--

--- a/package.xml
+++ b/package.xml
@@ -12,7 +12,7 @@
   <exec_depend>gazebo_ros</exec_depend>
   <exec_depend>gazebo</exec_depend>
   <exec_depend>gazebo_plugins</exec_depend>
-  <exec_depend>turtlebot3_description</exec_depend>
+  <!-- For AMCL and move_base -->
   <exec_depend>turtlebot3_navigation</exec_depend>
 
   <!-- SLAM -->


### PR DESCRIPTION
This is no longer needed and will cause unnecessary troubles when running in ROS Kinetic + gazebo 9.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.