### PR TITLE
Set objects to static to avoid wrong inertia in physics simulation

### DIFF
--- a/models/aws_robomaker_retail_MagicCube_01/model.sdf
+++ b/models/aws_robomaker_retail_MagicCube_01/model.sdf
@@ -32,5 +32,6 @@
         </meta>
       </visual>
     </link>
+    <static>1</static>    
   </model>
 </sdf>

--- a/models/aws_robomaker_retail_SecurityCamera_01/model.sdf
+++ b/models/aws_robomaker_retail_SecurityCamera_01/model.sdf
@@ -32,5 +32,6 @@
         </meta>
       </visual>
     </link>
+    <static>1</static>    
   </model>
 </sdf>


### PR DESCRIPTION
- It is intended for all objects to be static
- In case, users need non-static objects, just disable static flag and make sure object has correct mass and inertia

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
